### PR TITLE
Add Tailwind theme setup

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,19 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+html, body {
+  height: 100%;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  @apply bg-neutral-50 text-neutral-900 font-sans;
+}
+
+.card {
+  @apply bg-white rounded-lg shadow p-4;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,38 @@
+module.exports = {
+  darkMode: 'class',
+  content: [
+    './app/**/*.{js,ts,jsx,tsx,mdx}',
+    './components/**/*.{js,ts,jsx,tsx,mdx}',
+    './hooks/**/*.{js,ts,jsx,tsx,mdx}',
+    './lib/**/*.{js,ts,jsx,tsx,mdx}',
+  ],
+  theme: {
+    extend: {
+      colors: {
+        primary: '#0f172a',
+        secondary: '#1e293b',
+        accent: '#f97316',
+        success: '#16a34a',
+        warning: '#d97706',
+        error: '#dc2626',
+        neutral: {
+          50: '#f8fafc',
+          100: '#f1f5f9',
+          200: '#e2e8f0',
+          300: '#cbd5e1',
+          400: '#94a3b8',
+          500: '#64748b',
+          600: '#475569',
+          700: '#334155',
+          800: '#1e293b',
+          900: '#0f172a',
+        },
+      },
+      fontFamily: {
+        sans: ['Inter', 'ui-sans-serif', 'system-ui'],
+        display: ['Playfair Display', 'serif'],
+      },
+    },
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- configure Tailwind theme with project colors and fonts
- add global CSS with basic resets and card utility

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685ecc2958f8832db5b0e7fb085cd4ee